### PR TITLE
feat: make "type" field optional with "stdio" as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Here's an example using Context7 and Playwright MCP servers:
   "mcpServers": {
     "context7": {
 +     "description": "Use when you need to search library documentation.",
-      "type": "stdio",
+-     "type": "stdio",
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"],
       "env": {}
     },
     "playwright": {
 +     "description": "Use when you need to control or automate web browsers.",
-      "type": "stdio",
+-     "type": "stdio",
       "command": "npx",
       "args": ["-y", "@playwright/mcp@latest"],
       "env": {}
@@ -42,6 +42,8 @@ Here's an example using Context7 and Playwright MCP servers:
 ```
 
 The `description` field is the only extension to the standard MCP configuration. It helps the LLM understand each tool group's purpose without loading detailed tool schemas.
+
+**Note**: The `type` field defaults to `"stdio"` if not specified. For `stdio` type servers, you can omit the `type` field for cleaner configuration.
 
 ### 2. Register Modular MCP
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -10,7 +10,8 @@
             "type": "object",
             "properties": {
               "type": {
-                "const": "stdio"
+                "const": "stdio",
+                "default": "stdio"
               },
               "description": {
                 "type": "string"
@@ -31,11 +32,7 @@
                 }
               }
             },
-            "required": [
-              "type",
-              "description",
-              "command"
-            ]
+            "required": ["description", "command"]
           },
           {
             "type": "object",
@@ -56,11 +53,7 @@
                 }
               }
             },
-            "required": [
-              "type",
-              "description",
-              "url"
-            ]
+            "required": ["type", "description", "url"]
           },
           {
             "type": "object",
@@ -81,17 +74,11 @@
                 }
               }
             },
-            "required": [
-              "type",
-              "description",
-              "url"
-            ]
+            "required": ["type", "description", "url"]
           }
         ]
       }
     }
   },
-  "required": [
-    "mcpServers"
-  ]
+  "required": ["mcpServers"]
 }

--- a/config.example.json
+++ b/config.example.json
@@ -3,14 +3,12 @@
   "mcpServers": {
     "playwright": {
       "description": "Use when you need to control or automate web browsers.",
-      "type": "stdio",
       "command": "npx",
       "args": ["-y", "@playwright/mcp@latest"],
       "env": {}
     },
     "context7": {
       "description": "Use when you need to search library documentation.",
-      "type": "stdio",
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"],
       "env": {}

--- a/src/scripts/generate-schema.ts
+++ b/src/scripts/generate-schema.ts
@@ -1,7 +1,7 @@
+import { writeFile } from "node:fs/promises";
 import { toJsonSchema } from "@valibot/to-json-schema";
 import * as v from "valibot";
 import { mcpServerConfigSchema } from "../types.js";
-import { writeFile } from "node:fs/promises";
 
 const configJsonSchema = await toJsonSchema(
   v.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import * as v from "valibot";
 
 export const mcpServerConfigSchema = v.union([
   v.object({
-    type: v.literal("stdio"),
+    type: v.optional(v.literal("stdio"), "stdio"),
     /** Description of what this MCP server group provides */
     description: v.string(),
     command: v.string(),


### PR DESCRIPTION
## Summary

The `type` field in MCP server configuration now defaults to `"stdio"` when omitted, allowing for cleaner configuration files. This is especially useful since stdio is the most common transport type.

## Changes

- Updated type schema to make `type` optional with `"stdio"` as default value
- Updated example config to demonstrate the optional `type` field  
- Updated README with documentation about the default behavior
- Regenerated JSON schema to reflect the changes

## Example

Before:
```json
{
  "mcpServers": {
    "playwright": {
      "description": "Use when you need to control or automate web browsers.",
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "@playwright/mcp@latest"]
    }
  }
}
```

After:
```json
{
  "mcpServers": {
    "playwright": {
      "description": "Use when you need to control or automate web browsers.",
      "command": "npx",
      "args": ["-y", "@playwright/mcp@latest"]
    }
  }
}
```

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)