### PR TITLE
fix: limit env var substitution to ${VAR} format and add graceful fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ The `description` field is the only extension to the standard MCP configuration.
 Modular MCP supports environment variable interpolation in configuration files, allowing you to avoid committing sensitive information like API keys and tokens to version control.
 
 **Supported syntax**:
-- `$VAR` - Simple variable reference
-- `${VAR}` - Braced variable reference (useful when followed by other characters)
+- `${VAR}` - Braced variable reference
+
+**Note**: Only the `${VAR}` syntax is supported. The `$VAR` syntax (without braces) is intentionally not supported to avoid conflicts with values that legitimately contain dollar signs (e.g., tokens like `token$abc123`).
 
 **Where interpolation is supported**:
 - `stdio` servers: `args` array elements and `env` object values
@@ -70,9 +71,9 @@ Modular MCP supports environment variable interpolation in configuration files, 
     "my-server": {
       "description": "Example server with environment variables",
       "command": "node",
-      "args": ["$HOME/.local/bin/server.js", "--config=${XDG_CONFIG_HOME}/app/config.json"],
+      "args": ["${HOME}/.local/bin/server.js", "--config=${XDG_CONFIG_HOME}/app/config.json"],
       "env": {
-        "API_KEY": "$MY_API_KEY",
+        "API_KEY": "${MY_API_KEY}",
         "LOG_DIR": "${HOME}/logs"
       }
     },
@@ -81,7 +82,7 @@ Modular MCP supports environment variable interpolation in configuration files, 
       "type": "http",
       "url": "https://api.example.com",
       "headers": {
-        "Authorization": "Bearer $API_TOKEN"
+        "Authorization": "Bearer ${API_TOKEN}"
       }
     }
   }
@@ -90,7 +91,7 @@ Modular MCP supports environment variable interpolation in configuration files, 
 
 **Important notes**:
 - Environment variables must be set before starting Modular MCP
-- Missing environment variables will cause an error with a clear message
+- If a referenced environment variable is not defined, a warning will be logged and the original placeholder (e.g., `${UNDEFINED_VAR}`) will be preserved
 - Variables are substituted at load time, so the config file remains safe to commit
 
 ### 2. Register Modular MCP

--- a/config.example.json
+++ b/config.example.json
@@ -14,25 +14,25 @@
       "env": {}
     },
     "example-stdio-with-env-vars": {
-      "description": "Example showing environment variable interpolation in stdio servers. Supports both $VAR and ${VAR} syntax.",
+      "description": "Example showing environment variable interpolation in stdio servers. Only ${VAR} syntax is supported.",
       "command": "node",
       "args": [
-        "$HOME/.local/bin/my-script.js",
+        "${HOME}/.local/bin/my-script.js",
         "--config=${XDG_CONFIG_HOME}/app/config.json",
-        "--log-level=$LOG_LEVEL"
+        "--log-level=${LOG_LEVEL}"
       ],
       "env": {
-        "API_KEY": "$MY_API_KEY",
+        "API_KEY": "${MY_API_KEY}",
         "LOG_DIR": "${HOME}/logs",
-        "DATABASE_URL": "$DATABASE_URL"
+        "DATABASE_URL": "${DATABASE_URL}"
       }
     },
     "example-http-with-env-vars": {
       "type": "http",
       "description": "Example showing environment variable interpolation in HTTP servers.",
-      "url": "$API_BASE_URL/mcp",
+      "url": "${API_BASE_URL}/mcp",
       "headers": {
-        "Authorization": "Bearer $API_TOKEN",
+        "Authorization": "Bearer ${API_TOKEN}",
         "X-Custom-Header": "${CUSTOM_HEADER_VALUE}"
       }
     },
@@ -41,7 +41,7 @@
       "description": "Example showing environment variable interpolation in SSE servers.",
       "url": "${SSE_ENDPOINT}/events",
       "headers": {
-        "X-API-Key": "$SSE_API_KEY"
+        "X-API-Key": "${SSE_API_KEY}"
       }
     }
   }

--- a/src/utils/envSubstitution.test.ts
+++ b/src/utils/envSubstitution.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
 import {
   substituteEnvVars,
   substituteInArray,
@@ -7,6 +15,7 @@ import {
 
 describe("substituteEnvVars", () => {
   const originalEnv = process.env;
+  let consoleWarnSpy: MockInstance<typeof console.warn>;
 
   beforeEach(() => {
     // Reset process.env to a clean state with test variables
@@ -18,29 +27,23 @@ describe("substituteEnvVars", () => {
       API_KEY: "secret-key-123",
       EMPTY_VAR: "",
     };
+    // Spy on console.warn to verify warning messages
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     // Restore original process.env
     process.env = originalEnv;
+    consoleWarnSpy.mockRestore();
   });
 
-  describe("basic substitution", () => {
-    it("should substitute a single $VAR syntax", () => {
-      const result = substituteEnvVars("$TEST_VAR");
-      expect(result).toBe("test-value");
-    });
-
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+  describe("basic substitution with ${VAR} syntax", () => {
     // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
     it("should substitute a single ${VAR} syntax", () => {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
       const result = substituteEnvVars("${TEST_VAR}");
       expect(result).toBe("test-value");
-    });
-
-    it("should substitute $VAR in the middle of a string", () => {
-      const result = substituteEnvVars("prefix-$TEST_VAR-suffix");
-      expect(result).toBe("prefix-test-value-suffix");
     });
 
     // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
@@ -49,23 +52,69 @@ describe("substituteEnvVars", () => {
       const result = substituteEnvVars("prefix-${TEST_VAR}-suffix");
       expect(result).toBe("prefix-test-value-suffix");
     });
+
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    it("should substitute ${VAR} at the start of string", () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${TEST_VAR}-end");
+      expect(result).toBe("test-value-end");
+    });
+
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    it("should substitute ${VAR} at the end of string", () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("start-${TEST_VAR}");
+      expect(result).toBe("start-test-value");
+    });
+  });
+
+  describe("$VAR syntax should NOT be substituted", () => {
+    it("should NOT substitute $VAR syntax (remains as-is)", () => {
+      const result = substituteEnvVars("$TEST_VAR");
+      expect(result).toBe("$TEST_VAR");
+    });
+
+    it("should NOT substitute $VAR in the middle of a string", () => {
+      const result = substituteEnvVars("prefix-$TEST_VAR-suffix");
+      expect(result).toBe("prefix-$TEST_VAR-suffix");
+    });
+
+    it("should NOT substitute adjacent $VAR variables", () => {
+      const result = substituteEnvVars("$HOME$APP_NAME");
+      expect(result).toBe("$HOME$APP_NAME");
+    });
+
+    it("should preserve values like hoge$hoge", () => {
+      const result = substituteEnvVars("hoge$hoge");
+      expect(result).toBe("hoge$hoge");
+    });
+
+    it("should preserve complex token-like values with dollar signs", () => {
+      const result = substituteEnvVars("token$abc123$def");
+      expect(result).toBe("token$abc123$def");
+    });
   });
 
   describe("multiple variables", () => {
-    it("should substitute multiple variables in a string", () => {
-      const result = substituteEnvVars("$HOME/.config/$APP_NAME");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    it("should substitute multiple ${VAR} in a string", () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${HOME}/.config/${APP_NAME}");
       expect(result).toBe("/home/testuser/.config/myapp");
     });
 
-    it("should substitute adjacent variables", () => {
-      const result = substituteEnvVars("$HOME$APP_NAME");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    it("should substitute adjacent ${VAR} variables", () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${HOME}${APP_NAME}");
       expect(result).toBe("/home/testusermyapp");
     });
 
-    it("should substitute mixed syntax", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    it("should substitute ${VAR} but keep $VAR as-is in mixed syntax", () => {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
       const result = substituteEnvVars("$HOME/.config/${APP_NAME}");
-      expect(result).toBe("/home/testuser/.config/myapp");
+      expect(result).toBe("$HOME/.config/myapp");
     });
   });
 
@@ -81,62 +130,69 @@ describe("substituteEnvVars", () => {
     });
 
     it("should substitute variable with empty value", () => {
-      const result = substituteEnvVars("value:$EMPTY_VAR:end");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("value:${EMPTY_VAR}:end");
       expect(result).toBe("value::end");
     });
 
-    it("should handle variable at the start of string", () => {
-      const result = substituteEnvVars("$TEST_VAR-end");
-      expect(result).toBe("test-value-end");
-    });
-
-    it("should handle variable at the end of string", () => {
-      const result = substituteEnvVars("start-$TEST_VAR");
-      expect(result).toBe("start-test-value");
-    });
-
     it("should handle underscore in variable name", () => {
-      const result = substituteEnvVars("$API_KEY");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${API_KEY}");
       expect(result).toBe("secret-key-123");
     });
 
     it("should handle numbers in variable name", () => {
       // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires bracket notation for index signatures
       process.env["VAR123"] = "numeric-var";
-      const result = substituteEnvVars("$VAR123");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${VAR123}");
       expect(result).toBe("numeric-var");
     });
   });
 
-  describe("missing environment variables", () => {
-    it("should throw error for missing $VAR", () => {
-      expect(() => substituteEnvVars("$MISSING_VAR")).toThrow(
-        "Environment variable 'MISSING_VAR' is not defined",
-      );
-    });
-
+  describe("undefined environment variables (graceful fallback)", () => {
     // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
-    it("should throw error for missing ${VAR}", () => {
+    it("should NOT throw error for missing ${VAR}, return original with warning", () => {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
-      expect(() => substituteEnvVars("${MISSING_VAR}")).toThrow(
-        "Environment variable 'MISSING_VAR' is not defined",
+      const result = substituteEnvVars("${MISSING_VAR}");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      expect(result).toBe("${MISSING_VAR}");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Warning: Environment variable 'MISSING_VAR' is not defined. Keeping original placeholder.",
       );
     });
 
-    it("should throw error with context when part of larger string", () => {
-      expect(() => substituteEnvVars("prefix-$MISSING_VAR-suffix")).toThrow(
-        "Environment variable 'MISSING_VAR' is not defined",
-      );
+    it("should preserve multiple missing variables with warnings", () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${MISSING1}-${MISSING2}");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      expect(result).toBe("${MISSING1}-${MISSING2}");
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should substitute defined vars and preserve undefined vars", () => {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${HOME}/path/${UNDEFINED_VAR}");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      expect(result).toBe("/home/testuser/path/${UNDEFINED_VAR}");
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT warn for $VAR format (not matched at all)", () => {
+      const result = substituteEnvVars("$MISSING_VAR");
+      expect(result).toBe("$MISSING_VAR");
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
   });
 
   describe("special characters and partial matches", () => {
-    it("should not substitute partial matches", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    it("should handle ${VAR} with similar names correctly", () => {
       // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires bracket notation for index signatures
       process.env["HOME_DIR"] = "/home/dir";
-      const result = substituteEnvVars("$HOME_DIR");
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      const result = substituteEnvVars("${HOME_DIR}");
       expect(result).toBe("/home/dir");
-      // HOME should not match HOME_DIR
     });
 
     it("should handle dollar sign not part of variable pattern", () => {
@@ -149,11 +205,17 @@ describe("substituteEnvVars", () => {
       const result = substituteEnvVars("$$");
       expect(result).toBe("$$");
     });
+
+    it("should handle dollar sign at end of string", () => {
+      const result = substituteEnvVars("cost$");
+      expect(result).toBe("cost$");
+    });
   });
 });
 
 describe("substituteInObject", () => {
   const originalEnv = process.env;
+  let consoleWarnSpy: MockInstance<typeof console.warn>;
 
   beforeEach(() => {
     process.env = {
@@ -162,15 +224,19 @@ describe("substituteInObject", () => {
       LOG_DIR: "/var/log",
       HOME: "/home/user",
     };
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    consoleWarnSpy.mockRestore();
   });
 
-  it("should substitute all values in an object", () => {
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+  it("should substitute all values in an object using ${VAR} syntax", () => {
     const input = {
-      key1: "$API_KEY",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      key1: "${API_KEY}",
       // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
       key2: "${LOG_DIR}/app.log",
       key3: "no-vars",
@@ -185,31 +251,51 @@ describe("substituteInObject", () => {
     });
   });
 
+  it("should NOT substitute $VAR syntax in object values", () => {
+    const input = {
+      key1: "$API_KEY",
+      key2: "hoge$hoge",
+    };
+
+    const result = substituteInObject(input);
+
+    expect(result).toEqual({
+      key1: "$API_KEY",
+      key2: "hoge$hoge",
+    });
+  });
+
   it("should handle empty object", () => {
     const result = substituteInObject({});
     expect(result).toEqual({});
   });
 
   it("should not mutate original object", () => {
-    const input = { key: "$HOME" };
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    const input = { key: "${HOME}" };
     const result = substituteInObject(input);
 
     // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires bracket notation for index signatures
-    expect(input["key"]).toBe("$HOME");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    expect(input["key"]).toBe("${HOME}");
     // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires bracket notation for index signatures
     expect(result["key"]).toBe("/home/user");
   });
 
-  it("should throw error for missing variables in object values", () => {
-    const input = { key: "$MISSING" };
-    expect(() => substituteInObject(input)).toThrow(
-      "Environment variable 'MISSING' is not defined",
-    );
+  it("should preserve undefined variables with warning in object values", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    const input = { key: "${MISSING}" };
+    const result = substituteInObject(input);
+
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    expect(result).toEqual({ key: "${MISSING}" });
+    expect(consoleWarnSpy).toHaveBeenCalled();
   });
 });
 
 describe("substituteInArray", () => {
   const originalEnv = process.env;
+  let consoleWarnSpy: MockInstance<typeof console.warn>;
 
   beforeEach(() => {
     process.env = {
@@ -218,19 +304,24 @@ describe("substituteInArray", () => {
       CONFIG_DIR: "/etc/app",
       APP_NAME: "myapp",
     };
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    consoleWarnSpy.mockRestore();
   });
 
-  it("should substitute all elements in an array", () => {
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+  it("should substitute all elements in an array using ${VAR} syntax", () => {
     const input = [
-      "$HOME/.config",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      "${HOME}/.config",
       // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
       "${CONFIG_DIR}/config.json",
       "plain-string",
-      "$APP_NAME",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+      "${APP_NAME}",
     ];
 
     const result = substituteInArray(input);
@@ -243,23 +334,36 @@ describe("substituteInArray", () => {
     ]);
   });
 
+  it("should NOT substitute $VAR syntax in array elements", () => {
+    const input = ["$HOME/.config", "$APP_NAME", "hoge$hoge"];
+
+    const result = substituteInArray(input);
+
+    expect(result).toEqual(["$HOME/.config", "$APP_NAME", "hoge$hoge"]);
+  });
+
   it("should handle empty array", () => {
     const result = substituteInArray([]);
     expect(result).toEqual([]);
   });
 
   it("should not mutate original array", () => {
-    const input = ["$HOME"];
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    const input = ["${HOME}"];
     const result = substituteInArray(input);
 
-    expect(input[0]).toBe("$HOME");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    expect(input[0]).toBe("${HOME}");
     expect(result[0]).toBe("/home/user");
   });
 
-  it("should throw error for missing variables in array elements", () => {
-    const input = ["$MISSING"];
-    expect(() => substituteInArray(input)).toThrow(
-      "Environment variable 'MISSING' is not defined",
-    );
+  it("should preserve undefined variables with warning in array elements", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    const input = ["${MISSING}"];
+    const result = substituteInArray(input);
+
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Testing literal string substitution
+    expect(result).toEqual(["${MISSING}"]);
+    expect(consoleWarnSpy).toHaveBeenCalled();
   });
 });

--- a/src/utils/envSubstitution.ts
+++ b/src/utils/envSubstitution.ts
@@ -3,59 +3,64 @@ import type { McpServerConfig } from "../config/schema.js";
 /**
  * Environment variable substitution utility
  *
- * Supports both $VAR and ${VAR} syntax for environment variable interpolation.
- * Throws an error if a referenced environment variable is not defined.
+ * Supports only ${VAR} syntax for environment variable interpolation.
+ * The $VAR syntax is intentionally NOT supported to avoid issues with tokens
+ * and values containing dollar signs (e.g., "hoge$hoge").
+ *
+ * When a referenced environment variable is not defined, a warning is logged
+ * and the original placeholder is preserved (e.g., "${UNDEFINED_VAR}" stays as-is).
  */
 
 /**
  * Substitutes environment variables in a string.
  *
- * Supports both $VAR and ${VAR} syntax.
- * - $VAR matches word characters (letters, numbers, underscore)
+ * Only supports ${VAR} syntax.
  * - ${VAR} matches word characters within braces
+ * - $VAR syntax is NOT substituted (remains as-is)
  *
  * @param value - The string potentially containing environment variable references
  * @returns The string with environment variables substituted
- * @throws Error if a referenced environment variable is not defined
  *
  * @example
  * // With process.env.HOME = "/home/user"
- * substituteEnvVars("$HOME/.config") // returns "/home/user/.config"
  * substituteEnvVars("${HOME}/.config") // returns "/home/user/.config"
+ * substituteEnvVars("$HOME/.config") // returns "$HOME/.config" (NOT substituted)
+ * substituteEnvVars("${UNDEFINED}") // returns "${UNDEFINED}" (with warning)
  */
-export function substituteEnvVars(value: string): string {
+export const substituteEnvVars = (value: string): string => {
   // Pattern explanation:
-  // \$\{([A-Za-z_][A-Za-z0-9_]*)\} - matches ${VAR_NAME}
-  // \$([A-Za-z_][A-Za-z0-9_]*) - matches $VAR_NAME
+  // \$\{([A-Za-z_][A-Za-z0-9_]*)\} - matches ${VAR_NAME} only
   // Variable names must start with letter or underscore, followed by alphanumerics or underscores
-  const pattern = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+  // Note: $VAR syntax is intentionally NOT matched to preserve values like "hoge$hoge"
+  const pattern = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
 
-  return value.replace(pattern, (_match, bracedVar, unbracedVar) => {
-    const varName = bracedVar ?? unbracedVar;
-
+  return value.replace(pattern, (match, varName: string) => {
     if (!(varName in process.env)) {
-      throw new Error(`Environment variable '${varName}' is not defined`);
+      // biome-ignore lint/suspicious/noConsole: Intentional warning for undefined env vars
+      console.warn(
+        `Warning: Environment variable '${varName}' is not defined. Keeping original placeholder.`,
+      );
+      return match;
     }
 
     // Return the environment variable value (can be empty string)
     return process.env[varName] ?? "";
   });
-}
+};
 
 /**
  * Substitutes environment variables in all values of a record object.
  *
  * @param obj - Record object with string values
  * @returns New record object with substituted values
- * @throws Error if any referenced environment variable is not defined
  *
  * @example
  * // With process.env.API_KEY = "secret"
- * substituteInObject({ key: "$API_KEY" }) // returns { key: "secret" }
+ * substituteInObject({ key: "${API_KEY}" }) // returns { key: "secret" }
  */
-export function substituteInObject(
+export const substituteInObject = (
   obj: Record<string, string>,
-): Record<string, string> {
+): Record<string, string> => {
   const result: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(obj)) {
@@ -63,22 +68,20 @@ export function substituteInObject(
   }
 
   return result;
-}
+};
 
 /**
  * Substitutes environment variables in all elements of a string array.
  *
  * @param arr - Array of strings
  * @returns New array with substituted values
- * @throws Error if any referenced environment variable is not defined
  *
  * @example
  * // With process.env.HOME = "/home/user"
- * substituteInArray(["$HOME/.config"]) // returns ["/home/user/.config"]
+ * substituteInArray(["${HOME}/.config"]) // returns ["/home/user/.config"]
  */
-export function substituteInArray(arr: string[]): string[] {
-  return arr.map((element) => substituteEnvVars(element));
-}
+export const substituteInArray = (arr: string[]): string[] =>
+  arr.map((element) => substituteEnvVars(element));
 
 /**
  * Substitutes environment variables in a typed MCP server configuration.
@@ -86,7 +89,6 @@ export function substituteInArray(arr: string[]): string[] {
  *
  * @param config - Validated MCP server configuration (from Zod)
  * @returns New configuration with environment variables substituted
- * @throws Error if any referenced environment variable is not defined
  *
  * @example
  * // stdio server
@@ -94,13 +96,13 @@ export function substituteInArray(arr: string[]): string[] {
  *   type: "stdio",
  *   description: "Example",
  *   command: "node",
- *   args: ["$HOME/script.js"],
- *   env: { KEY: "$SECRET" }
+ *   args: ["${HOME}/script.js"],
+ *   env: { KEY: "${SECRET}" }
  * })
  */
-export function substituteInServerConfig(
+export const substituteInServerConfig = (
   config: McpServerConfig,
-): McpServerConfig {
+): McpServerConfig => {
   // Handle stdio type (default)
   if (!("type" in config) || config.type === "stdio") {
     return {
@@ -139,4 +141,4 @@ export function substituteInServerConfig(
   // This should never be reached due to Zod validation, but TypeScript needs exhaustiveness check
   const exhaustiveCheck: never = config;
   return exhaustiveCheck;
-}
+};


### PR DESCRIPTION
## Summary
Fix environment variable substitution to only process `${VAR}` format (not `$VAR`) and add graceful fallback with warning instead of throwing errors on undefined variables.

## Changes
- `src/utils/envSubstitution.ts` - Changed regex pattern to only match `${VAR}` format and modified error handling to log warnings instead of throwing
- `src/utils/envSubstitution.test.ts` - Added comprehensive test cases for new behavior

## Background
The previous implementation substituted both `${VAR}` and `$VAR` formats, which caused issues with tokens and other values containing `$` characters (e.g., `token$abc123`). Additionally, the error-throwing behavior on undefined variables caused the entire system to fail.

## Testing
- [ ] CI Pass
- [ ] `pnpm typecheck` passed
- [ ] `pnpm lint` passed
- [ ] `pnpm test` passed (37 tests)